### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 include = ["src", "Cargo.toml", "LICENSE", "README.md"]
 description = "An ic canister package"
 authors = ["Anubis Awooo"]
+repository = "https://github.com/AnubisAwooo/ic-canister-kit"
 
 # [lib]
 # path = "src/lib.rs"


### PR DESCRIPTION
to allow crates.io, rust-digger, and others to link to it